### PR TITLE
Update root README to describe project structure and workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ These were originally completed as coursework and have been imported from an old
 - Refactoring earlier work to match my current engineering practices
 
 Each project resides in `projects/` with:
-- \`*_original.py\` -- the version submitted for the class
-- \`*_refactored.py\` -- an updated version
-- \`tests/\` -- pytest tests for the refactored code
-- A per-project \`README.md\` describing the assignment and improvements
+- **A single `*.py` file** -- the *refactored* version. The original student submission is preserved in Git history, not as a separate file.
+- **A per-project `README.md`** -- describing the assignment and the improvements.
+- **Tests in the top-level `tests/` directory** with project names like `test_project_1_*.py`, `test_project_2_*.py`, etc.
+- **Two focused PRs per project**:
+    - `project-n-original` -- adds the **original version as submitted**
+    - `project-n-refactor` -- adds the **improved, modernized version**


### PR DESCRIPTION
Initially, I planned to maintain two files per project. One file would be the original submission, and another file for refactored updates to the project.

Ultimately, it is not necessary to maintain two separate files, when the original files can exist in the version history of this repository. As a result, this PR changes the root `README.md` to reflect this.

**Documentation**:
- Removes the reference to two separate `*.py` files
- Explains that there will be two main PR's focused on submitting the original file, and another for refactored files
- Clarifies that the original submission exists in the version history