### PR TITLE
Add Ruff linter configuration and integrate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Lint with Ruff
+        run: ruff check .
+
       - name: Run tests
         run: pytest || echo "No tests yet"
 

--- a/projects/project-1/animal.py
+++ b/projects/project-1/animal.py
@@ -1,9 +1,11 @@
 """
 Project 1 - Favorite Animal
 
-A simple introductory Python program that asks the user for their faorite animal and prints a message in response.
+A simple introductory Python program that asks the user for their favorite animal and
+prints a message in response.
 
-Originally written in January 2022 for OSU CS161 and later refactored for readability and structure.
+Originally written in January 2022 for OSU CS161 and later refactored for readability
+and structure.
 """
 
 def main() -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pytest
+ruff

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+# Ruff configuration
+
+line-length = 88
+target-version = "py311"
+
+[lint]
+# Select basi error + warning rules (similar to flake8: E, F, W)
+select = ["E", "F", "W"]
+
+ignore = [
+    # Add rule codes here to ignore them if needed in future
+]


### PR DESCRIPTION
This PR sets up Ruff as the Python linter for this repository and enforces
it in the continuous integration workflow.

### What’s included

- Added `ruff` to `requirements.txt`.
- Created a `ruff.toml` configuration with:
  - Python 3.11 target
  - Line length of 88
  - Basic lint rules (E, F, W) enabled
- Updated the GitHub Actions workflow (`ci.yml`) to run `ruff check .`
  before running the test suite.

### Why this change

This ensures that:

- All code merged into `main` adheres to consistent style and quality.
- PRs with linting errors cannot be merged.
