### PR TITLE
Add make_message helper and simple test for Project 1

### DIFF
--- a/projects/project_1/animal.py
+++ b/projects/project_1/animal.py
@@ -8,10 +8,14 @@ Originally written in January 2022 for OSU CS161 and later refactored for readab
 and structure.
 """
 
+def make_message(animal: str) -> str:
+    """Return the message printed by the program."""
+    return f"Your favorite animal is the {animal}."
+
 def main() -> None:
-    """Prompt the user for their favorite animal and print a message"""
-    favorite_animal = input("Please enter your favorite animal: ")
-    print(f"Your favorite animal is the {favorite_animal}.")
+    """Prompt the user for their favorite animal and print the message."""
+    favorite = input("Please enter your favorite animal: ")
+    print(make_message(favorite))
 
 
 if __name__ == "__main__":

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_project_1_animal.py
+++ b/tests/test_project_1_animal.py
@@ -1,0 +1,6 @@
+from projects.project_1.animal import make_message
+
+
+def test_make_message():
+    assert make_message("wolf") == "Your favorite animal is the wolf."
+


### PR DESCRIPTION
This PR adds a small pure function (`make_message`) to Project 1 to separate
the program's logic from its input/output. This preserves the original
assignment behavior while making the logic easy to test.

Changes included:
- Added `make_message()` to `projects/project_1/animal.py`.
- Created `projects/__init__.py` so Project 1 can be imported as a Python package.
- Added `pytest.ini` to include the repository root in the Python import path.
- Added a simple test (`tests/test_project_1_animal.py`) that imports and tests
  `make_message()` directly.

Ruff and pytest both pass locally in the .venv, and CI will enforce both.
